### PR TITLE
Display message when Outdoor Reference not selected

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -491,12 +491,18 @@ with tab2:
 
         # Pearson Corr vs Outdoor Reference
         st.header('Pearson Corr vs Outdoor Reference (Temp)')
-        cvt = compute_correlations(df, field='Temp_F')['Outdoor Reference']
-        st.table(cvt.reset_index().rename(columns={'index':'DeviceName','Outdoor Reference':'Corr'}))
+        if 'AS10' not in selected_devices:
+            st.info('Outdoor reference data must be selected to display Pearson Correlation')
+        else:
+            cvt = compute_correlations(df, field='Temp_F')['Outdoor Reference']
+            st.table(cvt.reset_index().rename(columns={'index':'DeviceName','Outdoor Reference':'Corr'}))
 
         st.header('Pearson Corr vs Outdoor Reference (RH)')
-        cvr = compute_correlations(df, field='RH')['Outdoor Reference']
-        st.table(cvr.reset_index().rename(columns={'index':'DeviceName','Outdoor Reference':'Corr'}))
+        if 'AS10' not in selected_devices:
+            st.info('Outdoor reference data must be selected to display Pearson Correlation')
+        else:
+            cvr = compute_correlations(df, field='RH')['Outdoor Reference']
+            st.table(cvr.reset_index().rename(columns={'index':'DeviceName','Outdoor Reference':'Corr'}))
 
         # Summary Statistics
         st.header('Summary Statistics (Temperature)')


### PR DESCRIPTION
## Summary
- show an info message if "Outdoor Reference" data isn't selected for the Pearson correlation calculation

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_b_685d5fb7facc83239981799d66710d2a